### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,11 @@ php:
   - 5.6
   - hhvm
 
-before_script:
-  - composer install --prefer-source --no-interaction --dev
+sudo: false
+
+install:
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpspec run --verbose --format=dot
   - vendor/bin/phpunit --verbose
-
-matrix:
-  allow_failures:
-    - php: hhvm
-  fast_finish: true


### PR DESCRIPTION
Setting `sudo: false` allows us to access travis' new faster environment, and I've improved the composer install. Also, we don't need to allow hhvm failures since the tests are passing fine.
