### PR TITLE
caller_permissions_override_role_permissions test throwing an exception

### DIFF
--- a/src/Tests/PersistentDriverTestCase.php
+++ b/src/Tests/PersistentDriverTestCase.php
@@ -285,7 +285,7 @@ abstract class PersistentDriverTestCase extends \PHPUnit_Framework_TestCase
         $lock = $this->getCallerLock();
         $lock->allow('create', 'posts');
 
-        $this->getRoleLock('user')->deny('user', 'create', 'posts');
+        $this->getRoleLock('user')->deny('create', 'posts');
 
         $this->assertTrue($lock->can('create', 'posts'));
     }


### PR DESCRIPTION
Seems like a typo SQLSTATE[HY000]: General error: 1366 Incorrect integer value: 'posts' for column 'resource_id' at row 1