### PR TITLE
Added 1.0-dev branch alias against dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,10 @@
             "stubs\\BeatSwitch\\Lock\\": "stubs/",
             "tests\\BeatSwitch\\Lock\\": "tests/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.3-dev"
+        }
     }
 }


### PR DESCRIPTION
Good Evening,
This PR adds a branch-alias to the composer.json file to give it a version constraint vs `dev-master`

Fixes #36 
