### PR TITLE
Expose permissions collection through all method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to Lock will be documented in this file. This file follows the *[Keep a CHANGELOG](http://keepachangelog.com/)* standards.
 
+## [Unreleased]
+- Added all method, this feature returns the permissions collection for a caller.
+
 ## 0.2.0 - 2015-09-16
 
 ### Added

--- a/spec/Callers/CallerLockSpec.php
+++ b/spec/Callers/CallerLockSpec.php
@@ -133,4 +133,13 @@ class CallerLockSpec extends ObjectBehavior
         $this->can('create', 'posts')->shouldReturn(true);
         $this->can('create', 'pages')->shouldReturn(false);
     }
+
+    function it_can_fetch_all_permissions()
+    {
+        $this->allow('login');
+        $this->allow('create', 'posts');
+        $this->deny('delete', 'users');
+
+        $this->all()->shouldBeArray();
+    }
 }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -223,6 +223,16 @@ abstract class Lock
     }
 
     /**
+     * Fetch collection of all caller permissions
+     *
+     * @return Permissions\Permission[]
+     */
+    public function all()
+    {
+        return $this->getPermissions();
+    }
+
+    /**
      * Determine if an action is allowed
      *
      * @param string $action


### PR DESCRIPTION
Good Evening!

Recently I've had the need to fetch all permissions of a caller for display on a table, the only way to accomplish this at the moment is to explicitly check `$action` on a caller.  The alternative is to code around this library which is not wonderful.
 
This feature exposes a collection of Permission objects.  Useful in situations where you need to display tables of permissions a user is allowed or denied.

The underlying getPermissions method is exposed as a public function "all".

Take care,
Nicholas