### PR TITLE
Changed visibility of method getPermissions from protected to public

### DIFF
--- a/src/Callers/CallerLock.php
+++ b/src/Callers/CallerLock.php
@@ -56,7 +56,7 @@ class CallerLock extends Lock
      *
      * @return \BeatSwitch\Lock\Permissions\Permission[]
      */
-    protected function getPermissions()
+    public function getPermissions()
     {
         return $this->getDriver()->getCallerPermissions($this->caller);
     }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -277,7 +277,7 @@ abstract class Lock
      *
      * @return \BeatSwitch\Lock\Permissions\Permission[]
      */
-    abstract protected function getPermissions();
+    abstract public function getPermissions();
 
     /**
      * Stores a permission into the driver

--- a/src/Roles/RoleLock.php
+++ b/src/Roles/RoleLock.php
@@ -49,7 +49,7 @@ class RoleLock extends Lock
      *
      * @return \BeatSwitch\Lock\Permissions\Permission[]
      */
-    protected function getPermissions()
+    public function getPermissions()
     {
         return $this->getPermissionsForRole($this->role);
     }


### PR DESCRIPTION
This change is useful to call getPermission() directly and get the list of permissions for a user, especially if the service who's asking for the permission doesn't have access to the list of allowed permission.
